### PR TITLE
Alert内のTextFieldに文字数制限をつける (Limit TextField input values in an AlertView)

### DIFF
--- a/Xib_Playground/Sources/ViewControllers/HomeViewController.swift
+++ b/Xib_Playground/Sources/ViewControllers/HomeViewController.swift
@@ -31,7 +31,39 @@ final class HomeViewController: UIViewController {
     // MARK: - View Life Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .white
+        let button = UIButton()
+        button.setTitle("Show Alert", for: .normal)
+        button.backgroundColor = .lightGray
+        button.frame.size = CGSize(width: 200, height: 60)
+        button.center = view.center
+        button.layer.cornerRadius = 16
+        button.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        view.addSubview(button)
         bind(to: viewModel)
+    }
+
+    @objc func buttonTapped() {
+        let alert: UIAlertController = UIAlertController(title: "Title", message: "Message", preferredStyle: UIAlertController.Style.alert)
+        alert.addTextField(configurationHandler: nil)
+        alert.textFields?.first?.placeholder = "Input Text"
+        alert.textFields?.first?.addTarget(self, action: #selector(textFieldDidChange), for: .allEditingEvents)
+        let saveTitleAction: UIAlertAction = UIAlertAction(title: "OK", style: UIAlertAction.Style.default, handler: { (_: UIAlertAction?) -> Void in
+            guard let text = alert.textFields?.first?.text, !text.isEmpty else {
+                return
+            }
+            print(text)
+        })
+        let cancelAction: UIAlertAction = UIAlertAction(title: "Cencel", style: UIAlertAction.Style.cancel, handler: nil)
+        alert.addAction(saveTitleAction)
+        alert.addAction(cancelAction)
+        present(alert, animated: true, completion: nil)
+    }
+
+    @objc func textFieldDidChange(_ textField: UITextField) {
+        if let text = textField.text, text.count > 5 {
+            textField.text = String(text.prefix(5))
+        }
     }
 
 }


### PR DESCRIPTION
### ブランチ
``` Swift
feature/textfield_in_alert_validation
```

### スクリーンショット
https://github.com/Masaya1582/Xib_Playground/assets/74645651/1baf8635-cb9c-494b-ad53-0d76f960f6de

