### PR TITLE
アイコンロングタップ時のリストにカスタムアイテムを追加する

### DIFF
--- a/Xib_Playground/Resources/Info.plist
+++ b/Xib_Playground/Resources/Info.plist
@@ -19,5 +19,18 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIApplicationShortcutItems</key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>camera</string>
+			<key>UIApplicationShortcutItemSubtitle</key>
+			<string>アイテムを出品</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>出品する</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>com.exhibit.button</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/Xib_Playground/SceneDelegate.swift
+++ b/Xib_Playground/SceneDelegate.swift
@@ -59,4 +59,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // to restore the scene back to its current state.
     }
 
+    func windowScene(_ windowScene: UIWindowScene, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
+        if shortcutItem.type == "com.exhibit.button" {
+            print("出品ボタンをタップしました")
+        }
+        completionHandler(true)
+    }
+
 }


### PR DESCRIPTION
## ブランチ
```swift
feature/longtap_custom_button
```

## スクリーンショット
| iOS | Android |
| -------- | --------|
| <img src="https://github.com/Masaya1582/Xib_Playground/assets/74645651/c028785d-79e5-407a-a54a-860758cc6b64" width="300" />  | <img src="" width="300" />